### PR TITLE
fix: release please

### DIFF
--- a/.github/workflows/prod-page-deploy.yml
+++ b/.github/workflows/prod-page-deploy.yml
@@ -1,0 +1,26 @@
+on: 
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: The branch to build
+        required: true
+
+jobs:
+  deploy: 
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      deployments: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Build
+        run: bun run cloudflare-step-deploy
+      - name: Publish
+        uses: cloudflare/pages-action@v1
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          projectName: ${{ vars.PAGES_PROJECT_NAME }} # e.g. 'my-project'
+          directory: ${{ vars.OUTPUT_DIRECTORY }} # e.g. 'dist'
+          gitHubToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -24,18 +24,13 @@ jobs:
           # (PAT) and configured it as a GitHub action secret named
           # `MY_RELEASE_PLEASE_TOKEN` (this secret name is not important).
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
-          target-branch: ${{ github.ref_name }}
+          target-branch: ${{ 'main' }}
           # this is a built-in strategy in release-please, see "Action Inputs"
           # for more options
           release-type: node
-          # Skip creating a release post on GitHub when it's a feature branch
-          skip-github-release: ${{ env.BRANCH_NAME != 'main' }}
-          # Create the tags when merging into to main since that's the real release after a rebase / squash
-          # Skip creating another PR for a new release since the release was just merged into main
-          skip-github-pull-request: ${{ env.BRANCH_NAME == 'main' }}
       - uses: actions/checkout@v4
       - name: tag major and minor versions
-        if: ${{ steps.release.outputs.release_created || env.BRANCH_NAME == 'main' }}
+        if: ${{ steps.release.outputs.release_created }}
         run: |
           git config user.name github-actions[bot]
           git config user.email 41898282+github-actions[bot]@users.noreply.github.com

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -24,10 +24,15 @@ jobs:
           # (PAT) and configured it as a GitHub action secret named
           # `MY_RELEASE_PLEASE_TOKEN` (this secret name is not important).
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
-          target-branch: ${{ 'main' }}
+          target-branch: ${{ github.ref_name }}
           # this is a built-in strategy in release-please, see "Action Inputs"
           # for more options
           release-type: node
+          # Skip creating a release post on GitHub when it's a feature branch
+          skip-github-release: ${{ env.BRANCH_NAME != 'main' }}
+          # Create the tags when merging into to main since that's the real release after a rebase / squash
+          # Skip creating another PR for a new release since the release was just merged into main
+          skip-github-pull-request: ${{ env.BRANCH_NAME == 'main' }}
       - uses: actions/checkout@v4
       - name: tag major and minor versions
         if: ${{ steps.release.outputs.release_created }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,8 +1,7 @@
 on:
   push:
     branches:
-      - '**'
-      - '!release-please-**'
+      - 'main'
 
 permissions:
   contents: write
@@ -28,11 +27,10 @@ jobs:
           # this is a built-in strategy in release-please, see "Action Inputs"
           # for more options
           release-type: node
-          # Skip creating a release post on GitHub when it's a feature branch
-          skip-github-release: ${{ env.BRANCH_NAME != 'main' }}
-          # Create the tags when merging into to main since that's the real release after a rebase / squash
-          # Skip creating another PR for a new release since the release was just merged into main
-          skip-github-pull-request: ${{ env.BRANCH_NAME == 'main' }}
+          # Because of this open issue, https://github.com/googleapis/release-please-action/issues/937
+          # when we set skip-pull-request to true but skip-release to false, the action does not make a release
+          # From how I read the docs, this seems like a bug, but I'm not in the mood to go down that rabbit hole now
+          # So for now, we will only activate the action on Main and accept PRs into main for the release
       - uses: actions/checkout@v4
       - name: tag major and minor versions
         if: ${{ steps.release.outputs.release_created }}
@@ -49,3 +47,8 @@ jobs:
           git tag -a v${{ steps.release.outputs.major }}.${{ steps.release.outputs.minor }}.${{ steps.release.outputs.patch }} -m "Release v${{ steps.release.outputs.major }}.${{ steps.release.outputs.minor }}.${{ steps.release.outputs.patch }}"
           git push origin v${{ steps.release.outputs.major }}
           git push origin v${{ steps.release.outputs.major }}.${{ steps.release.outputs.minor }}
+      - name: Deploy release to Production
+        uses: ./.github/workflows/prod-page-deploy.yml
+        with:
+          branch: ${{ env.BRANCH_NAME }}
+      

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -16,7 +16,8 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: googleapis/release-please-action@v4
+      - name: run release-please
+        uses: googleapis/release-please-action@v4
         id: release
         with:
           # this assumes that you have created a personal access token
@@ -31,7 +32,10 @@ jobs:
           # when we set skip-pull-request to true but skip-release to false, the action does not make a release
           # From how I read the docs, this seems like a bug, but I'm not in the mood to go down that rabbit hole now
           # So for now, we will only activate the action on Main and accept PRs into main for the release
-      - uses: actions/checkout@v4
+
+      - name: checkout
+        uses: actions/checkout@v4
+
       - name: tag major and minor versions
         if: ${{ steps.release.outputs.release_created }}
         run: |
@@ -47,7 +51,9 @@ jobs:
           git tag -a v${{ steps.release.outputs.major }}.${{ steps.release.outputs.minor }}.${{ steps.release.outputs.patch }} -m "Release v${{ steps.release.outputs.major }}.${{ steps.release.outputs.minor }}.${{ steps.release.outputs.patch }}"
           git push origin v${{ steps.release.outputs.major }}
           git push origin v${{ steps.release.outputs.major }}.${{ steps.release.outputs.minor }}
+
       - name: Deploy release to Production
+        if: ${{ steps.release.outputs.release_created }}
         uses: ./.github/workflows/prod-page-deploy.yml
         with:
           branch: ${{ env.BRANCH_NAME }}


### PR DESCRIPTION
Trying this out. 
Only use release-please on the main branch. When merging a PR or committing on main, release-please will create a PR. Once the PR is merged, release-please will make a release and tag the commit. This will only happen on the main branch. When a release is created, the output from the release-please step, `${{ steps.release.outputs.release_created }}`, will be set to true. This creates and pushes the tags. This will also trigger another workflow, `prod-page-deploy.yml`, to perform a prod deployment to the Cloudflare pages project. 